### PR TITLE
GP-40363 Add Order Type mapping

### DIFF
--- a/CRM/Donutapp/Processor/Greenpeace/Donation.php
+++ b/CRM/Donutapp/Processor/Greenpeace/Donation.php
@@ -319,16 +319,20 @@ class CRM_Donutapp_Processor_Greenpeace_Donation extends CRM_Donutapp_Processor_
    * @throws \CiviCRM_API3_Exception
    */
   protected function createWebshopOrder(CRM_Donutapp_API_Donation $donation, $contactId, $membershipId) {
+    $order_type = $donation->order_type;
     $shirt_type = $donation->shirt_type;
     $shirt_size = $donation->shirt_size;
-    if (empty($shirt_type) || empty($shirt_size)) {
+    $membership_type = $donation->membership_type;
+    if ((empty($shirt_type) || empty($shirt_size)) && empty($order_type)) {
       return FALSE;
     }
-    $shirt_type = str_replace('T-Shirt Modell:', '', $shirt_type);
-    $shirt_size = str_replace('T-Shirt Größe:', '', $shirt_size);
+    $shirt_type = str_replace('T-Shirt Modell:', '', $shirt_type ?? '');
+    $shirt_size = str_replace('T-Shirt Größe:', '', $shirt_size ?? '');
 
-    // @todo: should not be hardcoded in case we want to add other incentives
-    $order_type = 'T-Shirt';
+    if (!empty($order_type)) {
+      $order_type_map = Civi::settings()->get('donutapp_order_type_map');
+      $order_type = $order_type_map[$membership_type] ?? $order_type_map['default'];
+    }
 
     $params = [
       'target_id'        => $contactId,

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ and are used in this precedence:
   `['{donutapp_campaign_id}' => '{civicrm_campaign_id}']`.
 * Via the `campaign_id` parameter passed to the `import` API
 
+Webshop Order Types used when processing donations can be specified either by:
+
+* Using the `donutapp_order_type_map` setting, which maps membership type names
+  to order type names. Example: `{"Special_Membership_Type":"Special_Order_Type","default":"Fallback Order Type"}`
+* Using a `order_type` field in the Donation payload, e.g. if the order type
+  selection should be part of the donation form
+
 ## Known Issues
 
 * Only recurring donations are supported

--- a/settings/donutapp.setting.php
+++ b/settings/donutapp.setting.php
@@ -12,4 +12,15 @@ return [
     'is_contact'  => 0,
     'description' => ts('This maps campaigns in DonutApp to campaigns in CiviCRM.'),
   ],
+  'donutapp_order_type_map' => [
+    'name'        => 'donutapp_order_type_map',
+    'type'        => 'Array',
+    'html_type'   => 'text',
+    'default'     => [],
+    'add'         => '2.2',
+    'title'       => ts('DonutApp: Mapping of membership type name to order type name'),
+    'is_domain'   => 1,
+    'is_contact'  => 0,
+    'description' => ts('This maps membership types to order types. Key "default" can be used as a fallback.'),
+  ],
 ];


### PR DESCRIPTION
This allows webshop order types to be configured and mapped based on the membership type, with a default fallback option.

It also adds support for an optional order_type field in the Formunauts donation payload which would allow other order types to be used, e.g. based on form input.